### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,18 +5,18 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-OLED128x64   KEYWORD1	OLED128x64
+OLED128x64	KEYWORD1	OLED128x64
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-initOLED     KEYWORD2
-sendCharXY   KEYWORD2
-sendStrXY    KEYWORD2
-sendStringXY KEYWORD2
-clearDisplay KEYWORD2
-displayOn    KEYWORD2
-displayOff   KEYWORD2
-resetDisplay KEYWORD2
+initOLED	KEYWORD2
+sendCharXY	KEYWORD2
+sendStrXY	KEYWORD2
+sendStringXY	KEYWORD2
+clearDisplay	KEYWORD2
+displayOn	KEYWORD2
+displayOff	KEYWORD2
+resetDisplay	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords